### PR TITLE
Update azure-static-web-apps-black-smoke-0cf2a0210.yml

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-smoke-0cf2a0210.yml
+++ b/.github/workflows/azure-static-web-apps-black-smoke-0cf2a0210.yml
@@ -26,7 +26,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
-          output_location: "/out" # Built app content directory - optional
+          output_location: "out" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
output_location is relative to app_location, not an absolute Linux path. Microsoft’s Static Web Apps docs state that app_location points to the front-end source path, and output_location points to the folder where the built public files are generated; for most projects, output_location is relative to app_location.